### PR TITLE
Give bees jobs

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -26,6 +26,14 @@ function App(): JSX.Element {
     'honeycomb',
     variableDefaults.honeycomb
   );
+  const [drones, setDrones] = usePersistentState(
+    'drones',
+    variableDefaults.bees
+  );
+  const [workers, setWorkers] = usePersistentState(
+    'workers',
+    variableDefaults.bees
+  );
 
   // non-persistent varaibles (can be recalculated on page load)
   const [costOfNextBeeHoney, setCostOfNextBeeHoney] = useState(
@@ -125,6 +133,25 @@ function App(): JSX.Element {
     gatherRoyalJelly();
   };
 
+  const beesRemaining = () => {
+    return bees === 0;
+  };
+
+  const beeToDrone = () => {
+    if (bees === 0) {
+      return;
+    }
+    setBees((previousBees) => previousBees - 1);
+    setDrones((previousDrone) => previousDrone + 1);
+  };
+
+  const beeToWorker = () => {
+    if (bees === 0) {
+      return;
+    }
+    setBees((previousBees) => previousBees - 1);
+    setWorkers((previousWorker) => previousWorker + 1);
+  };
   // process a tick every 1 second
   useEffect(() => {
     const timer = setInterval(processTick, 1000);
@@ -138,6 +165,8 @@ function App(): JSX.Element {
     setNectar(variableDefaults.nectar);
     setRoyalJelly(variableDefaults.royalJelly);
     setHoneycomb(variableDefaults.honeycomb);
+    setDrones(variableDefaults.drones);
+    setWorkers(variableDefaults.workers);
   };
 
   return (
@@ -164,7 +193,18 @@ function App(): JSX.Element {
           </Button>
           cost of next bee: {costOfNextBeeHoney} honey,{' '}
           {costOfNextBeeRoyalJelly.toFixed(2)} royal jelly
-          <br /> <br /> <br />
+          <br /> <br />
+          <div>
+            <Button disabled={beesRemaining()} onClick={beeToDrone}>
+              assign a drone
+            </Button>
+            drones: {drones} <br /> <br />
+            <Button disabled={beesRemaining()} onClick={beeToWorker}>
+              assign a worker
+            </Button>
+            workers: {workers} <br />
+          </div>
+          <br /> <br />
           royal jelly: {royalJelly.toFixed(2)}
         </div>
         <div className="column right">

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -46,6 +46,7 @@ function App(): JSX.Element {
   const [canBuyNextBee, setCanBuyNextBee] = useState(false);
   const [canBuyHoneycomb, setCanBuyHoneycomb] = useState(false);
   const [canRefineNectar, setCanRefineNectar] = useState(false);
+  const [canAssignBee, setCanAssignBee] = useState(false);
 
   // mutators
   const gatherNectar = () => {
@@ -56,6 +57,12 @@ function App(): JSX.Element {
 
   const gatherRoyalJelly = () => {
     setRoyalJelly((previousRoyalJelly) => previousRoyalJelly + 0.27 * bees);
+  };
+
+  const createPupae = () => {
+    setPupae(
+      (previousPupae) => previousPupae + drones * staticConstants.PUPAE_BY_DRONE
+    );
   };
 
   const incrementNectarClicked = () => {
@@ -132,11 +139,15 @@ function App(): JSX.Element {
   const processTick = () => {
     gatherNectar();
     gatherRoyalJelly();
+    createPupae();
   };
 
-  const beesRemaining = () => {
+  const calcCanAssignBee = () => {
     return bees === 0;
   };
+  useEffect(() => {
+    setCanAssignBee(calcCanAssignBee);
+  }, [bees]);
 
   const beeToDrone = () => {
     if (bees === 0) {
@@ -198,14 +209,14 @@ function App(): JSX.Element {
           <br /> <br />
           <div className="row">
             <div className="column left">
-              <Button disabled={beesRemaining()} onClick={beeToDrone}>
+              <Button disabled={canAssignBee} onClick={beeToDrone}>
                 assign a drone
               </Button>
-              drones: {drones} <br />
-              pupae: {pupae} <br />
+              drones: {drones} <br /> <br />
+              pupae: {pupae.toFixed()}
             </div>
             <div className="column right">
-              <Button disabled={beesRemaining()} onClick={beeToWorker}>
+              <Button disabled={canAssignBee} onClick={beeToWorker}>
                 assign a worker
               </Button>
               workers: {workers} <br />

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -34,6 +34,7 @@ function App(): JSX.Element {
     'workers',
     variableDefaults.bees
   );
+  const [pupae, setPupae] = usePersistentState('pupae', variableDefaults.pupae);
 
   // non-persistent varaibles (can be recalculated on page load)
   const [costOfNextBeeHoney, setCostOfNextBeeHoney] = useState(
@@ -167,6 +168,7 @@ function App(): JSX.Element {
     setHoneycomb(variableDefaults.honeycomb);
     setDrones(variableDefaults.drones);
     setWorkers(variableDefaults.workers);
+    setPupae(variableDefaults.pupae);
   };
 
   return (
@@ -194,15 +196,20 @@ function App(): JSX.Element {
           cost of next bee: {costOfNextBeeHoney} honey,{' '}
           {costOfNextBeeRoyalJelly.toFixed(2)} royal jelly
           <br /> <br />
-          <div>
-            <Button disabled={beesRemaining()} onClick={beeToDrone}>
-              assign a drone
-            </Button>
-            drones: {drones} <br /> <br />
-            <Button disabled={beesRemaining()} onClick={beeToWorker}>
-              assign a worker
-            </Button>
-            workers: {workers} <br />
+          <div className="row">
+            <div className="column left">
+              <Button disabled={beesRemaining()} onClick={beeToDrone}>
+                assign a drone
+              </Button>
+              drones: {drones} <br />
+              pupae: {pupae} <br />
+            </div>
+            <div className="column right">
+              <Button disabled={beesRemaining()} onClick={beeToWorker}>
+                assign a worker
+              </Button>
+              workers: {workers} <br />
+            </div>
           </div>
           <br /> <br />
           royal jelly: {royalJelly.toFixed(2)}

--- a/src/constants/constants.tsx
+++ b/src/constants/constants.tsx
@@ -5,6 +5,8 @@
 const variableDefaults = {
   honey: 0,
   bees: 0,
+  drones: 0,
+  workers: 0,
   costOfNextBeeHoney: 1,
   costOfNextBeeRoyalJelly: 0,
   nectar: 0,

--- a/src/constants/constants.tsx
+++ b/src/constants/constants.tsx
@@ -18,7 +18,8 @@ const variableDefaults = {
 const staticConstants = {
   NECTAR_BY_BEE: 3,
   NECTAR_TO_HONEY_COST: 5,
-  HONEY_TO_HONEYCOMB_COST: 5
+  HONEY_TO_HONEYCOMB_COST: 5,
+  PUPAE_BY_DRONE: 0.1
 };
 
 export { variableDefaults, staticConstants };

--- a/src/constants/constants.tsx
+++ b/src/constants/constants.tsx
@@ -7,6 +7,7 @@ const variableDefaults = {
   bees: 0,
   drones: 0,
   workers: 0,
+  pupae: 0,
   costOfNextBeeHoney: 1,
   costOfNextBeeRoyalJelly: 0,
   nectar: 0,


### PR DESCRIPTION
You can chose to assign a bee to be either a drone or a worker.
- This substracts a bee
- Cost of next bee goes back down (do we want to count the drones + workers in the cost of next bee?) since the # bees decreases
- For every drone, they "make" 0.1 pupae. From a quick run, it might make more sense to decrease the number to 0.001 ( need 1000 drones to gain 1 pupae per second 
- Workers exist but do nothing yet